### PR TITLE
revert to unofficial image as official doesn't quite work

### DIFF
--- a/main.star
+++ b/main.star
@@ -1,6 +1,10 @@
-AUTOGPT_IMAGE="significantgravitas/auto-gpt:v0.3.0"
+AUTOGPT_IMAGE="significantgravitas/auto-gpt:0.2.2"
 REDIS_IMAGE="redis/redis-stack-server:latest"
 WEAVIATE_IMAGE="semitechnologies/weaviate:1.18.3"
+
+# The Auto-GPT team is being slow with releasing the new code on stable
+# using our own image for plugins in the meantime
+AUTOGPT_IMAGE_FOR_PLUGINS="h4ck3rk3y/autogpt"
 
 OPENAI_API_KEY_ARG="OPENAI_API_KEY"
 
@@ -66,10 +70,16 @@ def run(plan, args):
 
     plan.print("Starting AutoGpt with environment variables set to\n{0}".format(env_vars))
 
+    # using my own image while I wait for the AutoGPT team to release
+    # a stable image
+    image = AUTOGPT_IMAGE
+    if 'ALLOWLISTED_PLUGINS' in env_vars:
+        image = AUTOGPT_IMAGE_FOR_PLUGINS
+
     plan.add_service(
         name = "autogpt",
         config = ServiceConfig(
-            image = AUTOGPT_IMAGE,
+            image = image,
             entrypoint = ["sleep", "9999999"],
             env_vars = env_vars,
         )


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/app/autogpt/__main__.py", line 5, in <module>
    autogpt.cli.main()
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1635, in invoke
    rv = super().invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
Revert "use official image (#25)"
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/app/autogpt/cli.py", line 87, in main
    from autogpt.main import run_auto_gpt
  File "/app/autogpt/main.py", line 22, in <module>
    from scripts.install_plugin_deps import install_plugin_dependencies
ModuleNotFoundError: No module named 'scripts'
```

Getting the following with the official image
