### PR TITLE
fix: Handle invalid plugin name in input allowed list

### DIFF
--- a/main.star
+++ b/main.star
@@ -129,7 +129,7 @@ def run(plan, args):
                 plugins_to_download.append(plugin)
                 plugins_already_in_download_list.append(plugin_name)
             else:
-                fail("Invalid plugin name {0}.  The supported plugins are: {1}. You can add support for a new plugin by creating an issue or PR at {2} to get it added".format(plugin_name, ", ".join(plugins.plugins_map.keys()), "https://github.com/kurtosis-tech/autogpt-package"))
+                fail("Invalid plugin name {0}.  The supported plugins are: {1}. You can add support for a new plugin by creating an issue or PR at {2}".format(plugin_name, ", ".join(plugins.plugins_map.keys()), "https://github.com/kurtosis-tech/autogpt-package"))
 
         if plugins_to_download:
             download_plugins(plan, plugins_dir, plugins_to_download, plugin_branch_to_use, plugin_repo_to_use)

--- a/main.star
+++ b/main.star
@@ -120,7 +120,8 @@ def run(plan, args):
 
         plugins_to_download = list()
         plugins_already_in_download_list = list()
-        for plugin_name in env_vars['ALLOWLISTED_PLUGINS'].split(','):
+        plugins_names = env_vars['ALLOWLISTED_PLUGINS'].split(',')
+        for plugin_name in plugins_names:
             if plugin_name in plugins.plugins_map:
                 plugin = plugins.plugins_map[plugin_name]
                 if plugin_name in plugins_already_in_download_list:
@@ -128,7 +129,7 @@ def run(plan, args):
                 plugins_to_download.append(plugin)
                 plugins_already_in_download_list.append(plugin_name)
             else:
-                plan.print("{0} plugin isn't supported yet. Please create an issue or PR at {1} to get it added".format(plugin, "https://github.com/kurtosis-tech/autogpt-package"))            
+                fail("Invalid plugin name {0}.  The supported plugins are: {1}. You can add support for a new plugin by creating an issue or PR at {2} to get it added".format(plugin_name, ", ".join(plugins.plugins_map.keys()), "https://github.com/kurtosis-tech/autogpt-package"))
 
         if plugins_to_download:
             download_plugins(plan, plugins_dir, plugins_to_download, plugin_branch_to_use, plugin_repo_to_use)


### PR DESCRIPTION
An invalid plugin name in the input allowed list throws the following error:
```
There was an error interpreting Starlark code
Evaluation error: local variable plugin referenced before assignment
	at [github.com/kurtosis-tech/autogpt-package:131:121]: run

Error encountered running Starlark code.
```

Update the code to handle this error gracefully.
```
here was an error interpreting Starlark code
Evaluation error: fail: Invalid plugin name AutoGPTIFTTTWebhooksPlugin.  The supported plugins are: AutoGPTTwitter, AutoGPTEmailPlugin, AutoGPTSceneXPlugin, AutoGPTBingSearch, AutoGPTNewsSearch, AutoGPTWikipediaSearch, AutoGPTApiTools, AutoGPTRandomValues, AutoGPTSpacePlugin, AutoGPTGoogleAnalyticsPlugin, AutoGPTAlpacaTraderPlugin, AutoGPTUserInput, BingAI, AutoGPTCryptoPlugin. You can add support for a new plugin by creating an issue or PR at https://github.com/kurtosis-tech/autogpt-package
	at [github.com/kurtosis-tech/autogpt-package:132:21]: run
	at [0:0]: fail

Error encountered running Starlark code.
```